### PR TITLE
13 separate public and admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,8 @@ bundle exec rspec --exclude-pattern "spec/system/**/*.rb"
 - [x] Coverage Reporting
 - [ ] Achieve min. coverage of 80%
 - [ ] Consider use of GitHub projects for multi-part tasks
+- [ ] Separation into engines/packages:
+    - Helvellyn::Admin - Admin API for Helvellyn CMS
+    - Helvellyn::Api - Public API for Helvellyn CMS
+    - Helvellyn::Auth - Authentication API for Helvellyn CMS (I may have different plans for this)
+    - HelvellynJS - Frontend JavaScript

--- a/app/controllers/admin/content_entries_controller.rb
+++ b/app/controllers/admin/content_entries_controller.rb
@@ -1,0 +1,78 @@
+class Admin::ContentEntriesController < AdminController
+  before_action :set_workspace
+  before_action :set_content_type
+  before_action :set_content_entry, only: [:show, :edit, :update, :destroy]
+
+  # GET /workspaces/:workspace_id/content_types/:content_type_id/content_entries.json
+  # GET /:workspace_id/:content_type_id.json
+  def index
+    @content_entries = policy_scope(@content_type.content_entries)
+  end
+
+  # GET /workspaces/:workspace_id/content_types/:content_type_id/content_entries/:id.json
+  # GET /:workspace_id/:content_type_id/:id.json
+  def show
+  end
+
+  # GET /workspaces/:workspace_id/content_types/:content_type_id/content_entries/new.json
+  def new
+    @content_entry = @content_type.content_entries.build
+    authorize @content_entry
+  end
+
+  # GET /workspaces/:workspace_id/content_types/:content_type_id/content_entries/:id/edit.json
+  def edit
+  end
+
+  # POST /workspaces/:workspace_id/content_types/:content_type_id/content_entries.json
+  def create
+    @content_entry = @content_type.content_entries.build
+    @content_entry.assign_attributes(content_entry_params)
+    authorize @content_entry
+
+    if @content_entry.save
+      current_user.add_role :author, @content_entry
+      render :show, status: :created, location: [@workspace, @content_type, @content_entry]
+    else
+      render json: @content_entry.errors, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /workspaces/:workspace_id/content_types/:content_type_id/content_entries/:id.json
+  def update
+
+    if @content_entry.update(content_entry_params)
+      render :show, status: :ok, location: [@workspace, @content_type, @content_entry]
+    else
+      render json: @content_entry.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /workspaces/:workspace_id/content_types/:content_type_id/content_entries/:id.json
+  def destroy
+    @content_entry.destroy
+    format.json { head :no_content }
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_workspace
+      @workspace = Workspace.friendly.find(params[:workspace_id])
+    end
+
+    def set_content_type
+      @content_type = @workspace.content_types.friendly.find(params[:content_type_id])
+    end
+
+    def set_content_entry
+      @content_entry = @content_type.content_entries.friendly.find(params[:id])
+      authorize @content_entry
+    end
+
+    # Only allow a list of trusted parameters through.
+    def content_entry_params
+      content_type = @content_type.slug.to_sym
+      fields = @content_type.dynamic_attributes
+      params.require(content_type).permit(*fields, :slug, :published, :publish)
+    end
+end

--- a/app/controllers/admin/content_types_controller.rb
+++ b/app/controllers/admin/content_types_controller.rb
@@ -1,0 +1,61 @@
+class Admin::ContentTypesController < AdminController
+  before_action :set_workspace
+  before_action :set_content_type, only: [:show, :edit, :update, :destroy]
+
+  # GET /workspaces/:workspace_id/content_types.json
+  def index
+    @content_types = policy_scope(@workspace.content_types)
+  end
+
+  # GET /workspaces/:workspace_id/content_types/:id.json
+  def show
+  end
+
+  # GET /workspaces/:workspace_id/content_types/new.json
+  def new
+    @content_type = @workspace.content_types.build
+    authorize @content_type
+  end
+
+  # GET /workspaces/:workspace_id/content_types/:id/edit.json
+  def edit
+  end
+
+  # POST /workspaces/:workspace_id/content_types.json
+  def create
+    @content_type = @workspace.content_types.build(permitted_attributes(ContentType))
+    authorize @content_type
+
+    if @content_type.save
+      render :show, status: :created, location: [@workspace, @content_type]
+    else
+      render json: @content_type.errors, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /workspaces/:workspace_id/content_types/:id.json
+  def update
+    if @content_type.update(permitted_attributes(@content_type))
+      render :show, status: :ok, location: [@workspace, @content_type]
+    else
+      render json: @content_type.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /workspaces/:workspace_id/content_types/:id.json
+  def destroy
+    @content_type.destroy
+    head :no_content
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_workspace
+      @workspace = Workspace.friendly.find(params[:workspace_id])
+    end
+
+    def set_content_type
+      @content_type = @workspace.content_types.friendly.find(params[:id])
+      authorize @content_type
+    end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,24 @@
+class Admin::UsersController < AdminController
+  before_action :set_workspace
+  before_action :set_user, only: [:show, :edit, :update, :destroy]
+
+  # GET /workspaces/:workspace_id/users.json
+  def index
+    @users = policy_scope(@workspace.users)
+  end
+
+  # GET /workspaces/:workspace_id/users/:id.json
+  def show
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_workspace
+      @workspace = Workspace.friendly.find(params[:workspace_id])
+    end
+
+    def set_user
+      @user = @workspace.users.find(params[:id])
+      authorize @user
+    end
+end

--- a/app/controllers/admin/workspaces_controller.rb
+++ b/app/controllers/admin/workspaces_controller.rb
@@ -1,0 +1,58 @@
+class Admin::WorkspacesController < AdminController
+  before_action :set_workspace, only: [:show, :edit, :update, :destroy]
+
+  # GET /workspaces.json
+  def index
+    @workspaces = policy_scope(current_user.workspaces)
+  end
+
+  # GET /workspaces/:id.json
+  # GET /:id.json
+  def show
+  end
+
+  # GET /workspaces/new.json
+  def new
+    @workspace = current_user.workspaces.new
+    authorize @workspace
+  end
+
+  # GET /workspaces/:id/edit.json
+  def edit
+  end
+
+  # POST /workspaces.json
+  def create
+    @workspace = current_user.workspaces.build(permitted_attributes(Workspace))
+    authorize @workspace
+
+    if @workspace.save
+      current_user.add_role :admin, @workspace
+      render :show, status: :created, location: @workspace
+    else
+      render json: @workspace.errors, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /workspaces/:id.json
+  def update
+    if @workspace.update(permitted_attributes(@workspace))
+      render :show, status: :ok, location: @workspace
+    else
+      render json: @workspace.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /workspaces/:id.json
+  def destroy
+    @workspace.destroy
+    head :no_content
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_workspace
+      @workspace = Workspace.friendly.find(params[:id])
+      authorize @workspace
+    end
+end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,13 @@
+class AdminController < ApplicationController
+  def policy_scope(scope)
+    super([:admin, scope])
+  end
+
+  def authorize(record, query = nil)
+    super([:admin, record], query)
+  end
+
+  def permitted_attributes(record, action = action_name)
+    super([:admin, record], action)
+  end
+end

--- a/app/controllers/authentication/sessions_controller.rb
+++ b/app/controllers/authentication/sessions_controller.rb
@@ -1,4 +1,4 @@
-class Authentication::SessionsController < ApplicationController
+class Authentication::SessionsController < AuthenticationController
   before_action :set_session, only: [:show, :destroy]
 
   skip_before_action :authenticate!, only: [:new, :create]
@@ -16,14 +16,14 @@ class Authentication::SessionsController < ApplicationController
   # GET /sessions/new
   def new
     @session = Session.new
-    authorize [:authentication, @session]
+    authorize @session
   end
 
   # POST /sessions
   # POST /sessions.json
   def create
-    @session = Session.authenticate(permitted_attributes([:authentication, Session]))
-    authorize [:authentication, @session]
+    @session = Session.authenticate(permitted_attributes(Session))
+    authorize @session
 
     if @session.save
       render :show, status: :created, location: @session
@@ -46,6 +46,6 @@ class Authentication::SessionsController < ApplicationController
     # Use callbacks to share common setup or constraints between actions.
     def set_session
       @session = current_session
-      authorize [:authentication, @session]
+      authorize @session
     end
 end

--- a/app/controllers/authentication/users_controller.rb
+++ b/app/controllers/authentication/users_controller.rb
@@ -1,4 +1,4 @@
-class Authentication::UsersController < ApplicationController
+class Authentication::UsersController < AuthenticationController
   before_action :set_user, only: [:show, :edit, :update, :destroy]
 
   skip_before_action :authenticate!, only: [:new, :create]
@@ -11,14 +11,14 @@ class Authentication::UsersController < ApplicationController
   # GET /users/new
   def new
     @user = User.new
-    authorize [:authentication, @user]
+    authorize @user
   end
 
   # POST /users
   # POST /users.json
   def create
-    @user = User.new(permitted_attributes([:authentication, User]))
-    authorize [:authentication, @user]
+    @user = User.new(permitted_attributes(User))
+    authorize @user
 
     if @user.save
       @session = Session.create(user: @user)
@@ -35,7 +35,7 @@ class Authentication::UsersController < ApplicationController
   # PATCH/PUT /users/1
   # PATCH/PUT /users/1.json
   def update
-    if @user.update(permitted_attributes([:authentication, @user]))
+    if @user.update(permitted_attributes(@user))
       render :show, status: :ok, location: @user
     else
       render json: @user.errors, status: :unprocessable_entity
@@ -53,6 +53,6 @@ class Authentication::UsersController < ApplicationController
     # Use callbacks to share common setup or constraints between actions.
     def set_user
       @user = current_user
-      authorize [:authentication, @user]
+      authorize @user
     end  
 end

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -1,0 +1,13 @@
+class AuthenticationController < ApplicationController
+  def policy_scope(scope)
+    super([:authentication, scope])
+  end
+
+  def authorize(record, query = nil)
+    super([:authentication, record], query)
+  end
+
+  def permitted_attributes(record, action = action_name)
+    super([:authentication, record], action)
+  end
+end

--- a/app/javascript/src/axios.js
+++ b/app/javascript/src/axios.js
@@ -1,22 +1,40 @@
 import axios from 'axios'
 
-axios.defaults.baseURL = '/api'
+// Default settings
+axios.defaults.baseURL = '/admin'
 axios.defaults.headers.common['Accept'] = 'application/json'
 
-axios.interceptors.request.use(
-  (config) => {
-    let token = localStorage.getItem('user-token')
+// Interceptor Functions
+const interceptor = (config) => {
+  let token = localStorage.getItem('user-token')
 
-    if (token) {
-      config.headers['Authorization'] = `Bearer ${ token }`
-    }
-
-    return config
-  }, 
-
-  (error) => {
-    return Promise.reject(error)
+  if (token) {
+    config.headers['Authorization'] = `Bearer ${ token }`
   }
+
+  return config
+}
+
+const interceptorError = (error) => {
+  return Promise.reject(error)
+}
+
+// Axios Instances
+const adminAPI = axios.create()
+const authAPI = axios.create({
+  baseURL: '/auth'
+})
+
+adminAPI.interceptors.request.use(
+  interceptor, 
+  interceptorError
 )
 
-export default axios
+authAPI.interceptors.request.use(
+  interceptor, 
+  interceptorError
+)
+
+export default adminAPI
+
+export { authAPI }

--- a/app/javascript/src/store/authentication/sessions.js
+++ b/app/javascript/src/store/authentication/sessions.js
@@ -1,4 +1,4 @@
-import axios from '../../axios'
+import { authAPI as axios } from '../../axios'
 
 import prototype from '../prototypes/base'
 

--- a/app/javascript/src/store/authentication/users.js
+++ b/app/javascript/src/store/authentication/users.js
@@ -1,4 +1,4 @@
-import axios from '../../axios'
+import { authAPI as axios } from '../../axios'
 
 import prototype from '../prototypes/base'
 

--- a/app/policies/admin/content_entry_policy.rb
+++ b/app/policies/admin/content_entry_policy.rb
@@ -1,0 +1,36 @@
+class Admin::ContentEntryPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    record.published? || user&.has_any_role?({ name: :author, resource: record }, { name: :admin, resource: workspace })
+  end
+
+  def create?
+    user&.has_role?(:admin, workspace)
+  end
+
+  def update?
+    user&.has_any_role?({ name: :author, resource: record }, { name: :admin, resource: workspace })
+  end
+
+  def destroy?
+    user&.has_any_role?({ name: :author, resource: record }, { name: :admin, resource: workspace })
+  end
+
+  # Helper Methods
+  def workspace
+    record.content_type.workspace
+  end
+
+  class Scope < Scope
+    def resolve
+      if user
+        scope.all
+      else
+        scope.published
+      end
+    end
+  end
+end

--- a/app/policies/admin/content_type_policy.rb
+++ b/app/policies/admin/content_type_policy.rb
@@ -1,0 +1,42 @@
+class Admin::ContentTypePolicy < ApplicationPolicy
+  def permitted_attributes
+    [
+      :name,
+      :plural,
+      :slug,
+      :publishable,
+      fields: [
+        :name,
+        :type,
+        :sluggable
+      ]
+    ]
+  end
+
+  def show?
+    user&.has_any_role?({ name: :admin, resource: workspace }, { name: :moderator, resource: workspace }, { name: :member, resource: workspace })
+  end
+
+  def create?
+    user&.has_role?(:admin, workspace)
+  end
+
+  def update?
+    user&.has_role?(:admin, workspace)
+  end
+
+  def destroy?
+    user&.has_role?(:admin, workspace)
+  end
+
+  # Helper Methods
+  def workspace
+    record.workspace
+  end
+
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/policies/admin/user_policy.rb
+++ b/app/policies/admin/user_policy.rb
@@ -1,0 +1,7 @@
+class Admin::UserPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/policies/admin/workspace_policy.rb
+++ b/app/policies/admin/workspace_policy.rb
@@ -1,0 +1,23 @@
+class Admin::WorkspacePolicy < ApplicationPolicy
+  def permitted_attributes
+    [:title, :slug]
+  end
+
+  def show?
+    true
+  end
+
+  def update?
+    user&.has_role?(:admin, record)
+  end
+
+  def destroy?
+    user&.has_role?(:admin, record)
+  end
+
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/views/admin/content_entries/_content_entry.json.jbuilder
+++ b/app/views/admin/content_entries/_content_entry.json.jbuilder
@@ -1,0 +1,9 @@
+json.extract! content_entry, :id, :content_type_id, :slug, :created_at, :updated_at, :published_at, :generated_fields
+
+json.published content_entry.published
+
+content_entry.data.each do |key, value|
+  json.set! key, value
+end
+
+json.url pretty_workspace_content_type_content_entry_url(@workspace, @content_type, content_entry, format: :json)

--- a/app/views/admin/content_entries/index.json.jbuilder
+++ b/app/views/admin/content_entries/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @content_entries, partial: "admin/content_entries/content_entry", as: :content_entry

--- a/app/views/admin/content_entries/show.json.jbuilder
+++ b/app/views/admin/content_entries/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "admin/content_entries/content_entry", content_entry: @content_entry

--- a/app/views/admin/content_types/_content_type.json.jbuilder
+++ b/app/views/admin/content_types/_content_type.json.jbuilder
@@ -1,0 +1,3 @@
+json.extract! content_type, :id, :workspace_id, :name, :plural, :slug, :fields, :publishable, :created_at, :updated_at
+
+json.url workspace_content_type_url(content_type.workspace, content_type, format: :json)

--- a/app/views/admin/content_types/index.json.jbuilder
+++ b/app/views/admin/content_types/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @content_types, partial: "admin/content_types/content_type", as: :content_type

--- a/app/views/admin/content_types/show.json.jbuilder
+++ b/app/views/admin/content_types/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "admin/content_types/content_type", content_type: @content_type

--- a/app/views/admin/users/_user.json.jbuilder
+++ b/app/views/admin/users/_user.json.jbuilder
@@ -1,0 +1,5 @@
+json.extract! user, :id, :name, :email, :created_at, :updated_at
+
+json.role user.roles.find_by(resource_type: 'Workspace', resource_id: @workspace.id).name if @workspace
+
+json.url user_url(user, format: :json)

--- a/app/views/admin/users/index.json.jbuilder
+++ b/app/views/admin/users/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @users, partial: "admin/users/user", as: :user

--- a/app/views/admin/users/show.json.jbuilder
+++ b/app/views/admin/users/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "admin/users/user", user: @user

--- a/app/views/admin/workspaces/_workspace.json.jbuilder
+++ b/app/views/admin/workspaces/_workspace.json.jbuilder
@@ -1,0 +1,7 @@
+json.extract! workspace, :id, :user_id, :title, :slug, :created_at, :updated_at
+
+json.content_types do
+  json.array! workspace.content_types, partial: "admin/content_types/content_type", as: :content_type
+end
+
+json.url pretty_workspace_url(workspace, format: :json)

--- a/app/views/admin/workspaces/index.json.jbuilder
+++ b/app/views/admin/workspaces/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @workspaces, partial: "admin/workspaces/workspace", as: :workspace

--- a/app/views/admin/workspaces/show.json.jbuilder
+++ b/app/views/admin/workspaces/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "admin/workspaces/workspace", workspace: @workspace

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,41 +1,54 @@
 Rails.application.routes.draw do
-  scope '/api', format: false, defaults: { format: 'json' } do
-    constraints lambda { |req| req.format == :json } do # TODO: Does the above line now render this one redundant?
-      resources :workspaces, constraints: { id: /(?:[a-z0-9][._-]?)*[a-z0-9]/i } do
-        resources :users
-        resources :content_types do
-          resources :content_entries
-        end
+  # /admin/**/*.json Admin::
+  scope '/admin', module: 'admin', format: false, defaults: { format: 'json' } do
+    # /admin/workspaces/*.json
+    resources :workspaces, constraints: { id: /(?:[a-z0-9][._-]?)*[a-z0-9]/i } do
+      # /admin/workspaces/:workspace_id/users/*.json
+      resources :users
+      # /admin/workspaces/:workspace_id/content_types/*.json
+      resources :content_types do
+        # /admin/workspaces/:workspace_id/content_types/:content_type_id/content_entries/*.json
+        resources :content_entries
       end
+    end
+  end
 
-      scope module: 'authentication' do
-        post 'login', to: 'sessions#create'
-        post 'signup', to: 'users#create'
-        delete 'signout', to: 'sessions#destroy'
+  # /auth/**/*.json Authentication::
+  scope '/auth', module: 'authentication', format: false, defaults: { format: 'json' } do
+    # /auth/login.json
+    post 'login', to: 'sessions#create'
+    # /auth/signup.json
+    post 'signup', to: 'users#create'
+    # /auth/signout.json
+    delete 'signout', to: 'sessions#destroy'
 
-        scope '/account' do
-          resources :sessions, except: [:new, :create, :edit, :update]
-          resource :user, path: '', except: [:new, :create]
-        end
-      end
+    # /auth/account/**/*.json
+    scope '/account' do
+      # /auth/account/sessions/*.json
+      resources :sessions, except: [:new, :create, :edit, :update]
+      # /auth/account/*.json
+      resource :user, path: '', except: [:new, :create]
+    end
+  end
 
-      # Pretty Routes
-      scope as: 'pretty' do
-        resources :workspaces, path: '', constraints: { id: /(?:[a-z0-9][._-]?)*[a-z0-9]/i }, only: [:show] do
-          resources :users
-          resources :content_types, path: '', only: [] do
-            resources :content_entries, path: '', only: [:index, :show]
-          end
-        end
+  # Pretty Routes
+  # /api/**/*.json
+  scope '/api', as: 'pretty', format: false, defaults: { format: 'json' } do
+    # /api/:worspace_id/*.json
+    resources :workspaces, path: '', constraints: { id: /(?:[a-z0-9][._-]?)*[a-z0-9]/i }, only: [:show] do
+      # /api/:worspace_id/users/*.json
+      resources :users
+      resources :content_types, path: '', only: [] do
+        # /api/:worspace_id/:content_type_id/*.json
+        resources :content_entries, path: '', only: [:index, :show]
       end
     end
   end
 
   scope format: false, defaults: { format: 'html' } do
-    constraints lambda { |req| req.format == :html } do # TODO: Does the above line now render this one redundant?
-      # Catch all requests and render Vue app.
-      root to: 'application#render_application'
-      get '*path', to: 'application#render_application'
-    end
+    # Catch all requests and render Vue app.
+    root to: 'application#render_application'
+    get '*path', to: 'application#render_application'
   end
 end
+

--- a/spec/policies/admin/content_entry_policy_spec.rb
+++ b/spec/policies/admin/content_entry_policy_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Admin::ContentEntryPolicy, type: :policy do
+  let(:user) { User.new }
+
+  subject { described_class }
+
+  permissions ".scope" do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :show? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :create? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :update? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :destroy? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+end

--- a/spec/policies/admin/content_type_policy_spec.rb
+++ b/spec/policies/admin/content_type_policy_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Admin::ContentTypePolicy, type: :policy do
+  let(:user) { User.new }
+
+  subject { described_class }
+
+  permissions ".scope" do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :show? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :create? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :update? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :destroy? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+end

--- a/spec/policies/admin/user_policy_spec.rb
+++ b/spec/policies/admin/user_policy_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Admin::UserPolicy, type: :policy do
+  let(:user) { User.new }
+
+  subject { described_class }
+
+  permissions ".scope" do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :show? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :create? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :update? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :destroy? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+end

--- a/spec/policies/admin/workspace_policy_spec.rb
+++ b/spec/policies/admin/workspace_policy_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Admin::WorkspacePolicy, type: :policy do
+  let(:user) { User.new }
+
+  subject { described_class }
+
+  permissions ".scope" do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :show? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :create? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :update? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :destroy? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## Linked Issue(s)

- closes #13 

## Description

- [x] Feature

Creates a new namespace for Admin controllers, separates this from existing Authentication logic and the public API.

Frontend now contains two Axios instances: adminAPI (exported as default) and authAPI. There is no axios configuration for the API scope (the public interface) as this does not need to be accessed by the admin dashboard.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/thombruce/helvellyn/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/thombruce/helvellyn/blob/master/CODE_OF_CONDUCT.md)
