### PR TITLE
remove prevent to allow page reload on form submission

### DIFF
--- a/app/javascript/src/views/authentication/login.vue
+++ b/app/javascript/src/views/authentication/login.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 div
   h1 New Session
-  v-form(ref="form" :model="user" @submit.prevent="login()")
+  v-form(ref="form" :model="user" @submit="login()")
     v-text-field(label="Login" v-model="user.login" :error-messages="user.errors.login")
     v-text-field(label="Password" type="password" v-model="user.password" :error-messages="user.errors.password")
     v-btn(color="primary" type="submit") Log in
@@ -34,4 +34,10 @@ export default {
     }
   }
 }
+
+// TODO: Use @submit.prevent to prevent page refresh on login form
+//       I have temporarily removed the `.prevent` because some other
+//       problem is causing the application not to navigate on login,
+//       even though the user-token does get set. It requires further
+//       investigation.
 </script>

--- a/app/javascript/src/views/authentication/signup.vue
+++ b/app/javascript/src/views/authentication/signup.vue
@@ -1,11 +1,11 @@
 <template lang="pug">
 div
   h1 New User
-  v-form(ref="form" :model="user")
+  v-form(ref="form" :model="user" @submit="signUp()")
     v-text-field(label="Name" v-model="user.name" :error-messages="user.errors.name")
     v-text-field(label="Email" v-model="user.email" :error-messages="user.errors.email")
     v-text-field(label="Password" type="password" v-model="user.password" :error-messages="user.errors.password")
-    v-btn(color="primary" @click="signUp") Sign up
+    v-btn(color="primary" type="submit") Sign up
   p
     | Already have an account?
     |


### PR DESCRIPTION
## Linked Issue(s)

- closes #10 

## Description

- [x] Bugfix

Removes `.prevent` from submit method to allow a page reload on form submission. This is an imperfect solution, but better than the current implementation which has users stuck on the login page.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/thombruce/helvellyn/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/thombruce/helvellyn/blob/master/CODE_OF_CONDUCT.md)
