### PR TITLE
add warning and second step to record deletion

### DIFF
--- a/app/javascript/src/components/VDynamicFieldForm.vue
+++ b/app/javascript/src/components/VDynamicFieldForm.vue
@@ -1,5 +1,10 @@
 <template lang="pug">
-v-card.mb-5
+v-alert.my-2(
+  type="primary"
+  colored-border
+  border="left"
+  elevation="2"
+)
   v-container
     h4 {{ inputVal.name || 'New Field' }}
 

--- a/app/javascript/src/views/authentication/account.vue
+++ b/app/javascript/src/views/authentication/account.vue
@@ -6,13 +6,36 @@ div(v-if="user")
     v-text-field(label="Email" v-model="user.email" :error-messages="user.errors.email")
     v-text-field(label="Password" type="password" v-model="user.password" :error-messages="user.errors.password")
     v-btn(color="primary" @click="update") Submit
-  a(v-on:click.stop="destroy" href="javascript:;") Delete
+
+  v-alert.my-4(
+    type="error"
+    colored-border
+    border="left"
+    elevation="2"
+  )
+    h4.title Danger Zone
+    p.body-1 Your account cannot be restored if deleted. Please be certain this is what you want.
+    p.body-2 You will also lose all of the workspaces, templates and entities associated with this account.
+    v-dialog(v-model="dialog" persistent max-width="600px")
+      template(v-slot:activator="{ on }")
+        v-btn(color="error" v-on="on") Delete Account
+      v-card
+        v-card-title
+          span(class="headline") Delete Account
+        v-card-text
+          p.body-2 All of your workspace, templates and content entries associated with this account will be lost.
+          p.body-1 Are you sure you want to delete your account?
+        v-card-actions
+          v-spacer
+          v-btn(@click="dialog = false") Cancel
+          v-btn(color="error" @click="destroy") Delete Account
 </template>
 
 <script>
 export default {
   data() {
     return {
+      dialog: false,
       user: {
         errors: []
       }

--- a/app/javascript/src/views/entities/edit.vue
+++ b/app/javascript/src/views/entities/edit.vue
@@ -2,7 +2,29 @@
 div(v-if="entity")
   h2 Edit {{ template.name }}
   entity-form(:template="template" :entity="entity", :submit="update")
-  a(v-on:click.stop="destroy" href="javascript:;") Delete
+  
+  v-alert.my-4(
+    type="error"
+    colored-border
+    border="left"
+    elevation="2"
+  )
+    h4.title Danger Zone
+    p.body-1 Your {{ template.name }} cannot be restored if deleted. Please be certain this is what you want.
+    v-dialog(v-model="dialog" persistent max-width="600px")
+      template(v-slot:activator="{ on }")
+        v-btn(color="error" v-on="on") Delete {{ template.name }}
+      v-card
+        v-card-title
+          span(class="headline") Delete this {{ template.name }}
+        v-card-text
+          p.body-2 Your {{ template.name }} cannot be restored if deleted.
+          p.body-1 Are you sure you want to delete this {{ template.name }}?
+        v-card-actions
+          v-spacer
+          v-btn(@click="dialog = false") Cancel
+          v-btn(color="error" @click="destroy") Delete {{ template.name }}
+  
   router-link(:to="{ name: 'entity_path', params: { entity_id: $route.params.entity_id } }") Back
 </template>
 
@@ -15,6 +37,7 @@ export default {
   },
   data() {
     return {
+      dialog: false,
       entity: {
         errors: []
       }

--- a/app/javascript/src/views/templates/_form.vue
+++ b/app/javascript/src/views/templates/_form.vue
@@ -10,43 +10,47 @@ v-form(ref="form" :model="template")
 
   v-text-field(label="Slug" :prefix="workspaceUrl" v-model="template.slug" :error-messages="template.errors.slug" hint="The URL path of your content type (e.g. posts)")
 
-  h3 Publishing Settings
+  v-card.my-4
+    v-card-text
+      h3 Publishing Settings
 
-  v-checkbox(v-model="template.publishable" label="Publishable" hint="Whether or not it should be possible to publish the content, making it public.")
+      v-checkbox(v-model="template.publishable" label="Publishable" hint="Whether or not it should be possible to publish the content, making it public.")
 
-  h4 API Ordering
+      v-row
+        v-col
+          h4 API Ordering
+          v-select(label="Order by" :items="sortCandidates" v-model="template.api_sort")
+          v-checkbox(label="Most recent first" v-model="template.api_desc")
 
-  v-select(label="Order by" :items="sortCandidates" v-model="template.api_sort")
-  v-checkbox(label="Most recent first" v-model="template.api_desc")
+        v-col
+          h4 Admin Ordering
+          v-select(label="Order by" :items="sortCandidates" v-model="template.admin_sort")
+          v-checkbox(label="Most recent first" v-model="template.admin_desc")
 
-  h4 Admin Ordering
+  v-card.my-4
+    v-card-text
+      h3 Custom Fields
 
-  v-select(label="Order by" :items="sortCandidates" v-model="template.admin_sort")
-  v-checkbox(label="Most recent first" v-model="template.admin_desc")
+      v-select(label="Slug" :items="sluggableCandidates" v-model="template.sluggable_field")
 
-  div.mb-5
-    h3 Custom Fields
+      v-dynamic-field-form(v-for="(field, i) in template.fields" v-model="template.fields[i]")
 
-    v-select(label="Slug" :items="sluggableCandidates" v-model="template.sluggable_field")
-
-    v-dynamic-field-form(v-for="(field, i) in template.fields" v-model="template.fields[i]")
-
-    v-dialog(v-model="dialog" persistent max-width="600px")
-      template(v-slot:activator="{ on }")
-        v-btn(color="primary" v-on="on") Add Field
-      v-card
-        v-card-title
-          span(class="headline") New Field
-        v-container
-          v-row
-            v-col(v-for="field_type in field_types" cols="12" sm="6")
-              v-card(@click="addField(field_type.value)")
-                v-card-text.text-center
-                  v-icon(x-large) {{ field_type.icon }}
-                  p.headline {{ field_type.text }}
-        v-card-actions
-          v-spacer
-          v-btn(color="blue darken-1" text @click="dialog = false") Save
+      v-dialog(v-model="dialog" persistent max-width="600px")
+        template(v-slot:activator="{ on }")
+          v-btn(color="primary" v-on="on") Add Field
+        v-card
+          v-card-title
+            span(class="headline") New Field
+          v-container
+            v-row
+              v-col(v-for="field_type in field_types" cols="12" sm="6")
+                v-card(@click="addField(field_type.value)")
+                  v-card-text.text-center
+                    v-icon(x-large) {{ field_type.icon }}
+                    p.headline {{ field_type.text }}
+          v-card-actions
+            v-spacer
+            v-btn(color="blue darken-1" text @click="dialog = false") Save
 
   v-btn(color="primary" @click="submit") Submit
 </template>

--- a/app/javascript/src/views/templates/edit.vue
+++ b/app/javascript/src/views/templates/edit.vue
@@ -2,7 +2,30 @@
 div(v-if="template")
   h2 {{ template.plural }} Settings
   template-form(v-if="template" :workspace="workspace" :template="template", :submit="update")
-  a(v-on:click.stop="destroy" href="javascript:;") Delete
+
+  v-alert.my-4(
+    type="error"
+    colored-border
+    border="left"
+    elevation="2"
+  )
+    h4.title Danger Zone
+    p.body-1 Your template cannot be restored if deleted. Please be certain this is what you want.
+    p.body-2 You will also lose all of the entities associated with this template.
+    v-dialog(v-model="dialog" persistent max-width="600px")
+      template(v-slot:activator="{ on }")
+        v-btn(color="error" v-on="on") Delete Template
+      v-card
+        v-card-title
+          span(class="headline") Delete this Template
+        v-card-text
+          p.body-2 All of your content entries associated with this template will be lost.
+          p.body-1 Are you sure you want to delete this template?
+        v-card-actions
+          v-spacer
+          v-btn(@click="dialog = false") Cancel
+          v-btn(color="error" @click="destroy") Delete Template
+
   router-link(:to="{ name: 'entities_path', params: { template_id: $route.params.template_id } }") Back
 </template>
 
@@ -15,6 +38,7 @@ export default {
   },
   data() {
     return {
+      dialog: false,
       template: null
     }
   },

--- a/app/javascript/src/views/workspaces/edit.vue
+++ b/app/javascript/src/views/workspaces/edit.vue
@@ -4,7 +4,30 @@ div
     v-col
       h1 Edit Workspace
       workspace-form(:workspace="workspace", :submit="update")
-      a(v-on:click.stop="destroy" href="javascript:;") Delete
+
+      v-alert.my-4(
+        type="error"
+        colored-border
+        border="left"
+        elevation="2"
+      )
+        h4.title Danger Zone
+        p.body-1 Your workspace cannot be restored if deleted. Please be certain this is what you want.
+        p.body-2 You will also lose all of the templates and entities associated with this workspace.
+        v-dialog(v-model="dialog" persistent max-width="600px")
+          template(v-slot:activator="{ on }")
+            v-btn(color="error" v-on="on") Delete Workspace
+          v-card
+            v-card-title
+              span(class="headline") Delete this Workspace
+            v-card-text
+              p.body-2 All of your templates and content entries associated with this workspace will be lost.
+              p.body-1 Are you sure you want to delete this workspace?
+            v-card-actions
+              v-spacer
+              v-btn(@click="dialog = false") Cancel
+              v-btn(color="error" @click="destroy") Delete Workspace
+
       router-link(:to="{ name: 'templates_path', params: { workspace_id: $route.params.workspace_id } }") Back
 </template>
 
@@ -16,6 +39,7 @@ export default {
   },
   data() {
     return {
+      dialog: false,
       workspace: {
         errors: []
       }


### PR DESCRIPTION
## Linked Issue(s)

- closes #34

## Description

- [x] Feature

- Adds "Danger Zone" to User, Workspace, Template and Entity edit pages.
- Moves delete link to delete button in "Danger Zone"
- Adds confirmation step to deletion of these records.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/thombruce/helvellyn/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/thombruce/helvellyn/blob/master/CODE_OF_CONDUCT.md)
