### PR TITLE
add regeneratable token to Workspace

### DIFF
--- a/app/controllers/admin/workspaces_controller.rb
+++ b/app/controllers/admin/workspaces_controller.rb
@@ -1,5 +1,5 @@
 class Admin::WorkspacesController < AdminController
-  before_action :set_workspace, only: [:show, :edit, :update, :destroy]
+  before_action :set_workspace, only: [:show, :edit, :update, :token, :destroy]
 
   # GET /workspaces.json
   def index
@@ -37,6 +37,14 @@ class Admin::WorkspacesController < AdminController
   # PATCH/PUT /workspaces/:id.json
   def update
     if @workspace.update(permitted_attributes(@workspace))
+      render :show, status: :ok, location: @workspace
+    else
+      render json: @workspace.errors, status: :unprocessable_entity
+    end
+  end
+
+  def token
+    if @workspace.regenerate_token
       render :show, status: :ok, location: @workspace
     else
       render json: @workspace.errors, status: :unprocessable_entity

--- a/app/controllers/admin/workspaces_controller.rb
+++ b/app/controllers/admin/workspaces_controller.rb
@@ -44,7 +44,7 @@ class Admin::WorkspacesController < AdminController
   end
 
   def token
-    if @workspace.regenerate_token
+    if @workspace.session.regenerate_token
       render :show, status: :ok, location: @workspace
     else
       render json: @workspace.errors, status: :unprocessable_entity

--- a/app/javascript/src/store/workspaces.js
+++ b/app/javascript/src/store/workspaces.js
@@ -52,6 +52,17 @@ const actions = {
         return Promise.reject(error.response.data)
       })
   },
+  token({ state, commit }, params) {
+    return axios
+      .patch('/workspaces/' + params.workspace_id + '/token')
+      .then((res) => {
+        commit('modify', { slug: params.workspace_id, data: res.data })
+        return Promise.resolve(state.list[res.data.slug])
+      })
+      .catch((error) => {
+        return Promise.reject(error.response.data)
+      })
+  },
   destroy({ commit }, params) {
     return axios
       .delete('/workspaces/' + params.workspace_id)

--- a/app/javascript/src/views/workspaces/edit.vue
+++ b/app/javascript/src/views/workspaces/edit.vue
@@ -6,6 +6,26 @@ div
       workspace-form(:workspace="workspace", :submit="update")
 
       v-alert.my-4(
+        type="warning"
+        colored-border
+        border="left"
+        elevation="2"
+      )
+        h4.title API token
+        p.body-1 This is your token for accessing the API.
+        p.body-2 Be careful when regenerating this; your old token will stop working immediately, and you will be provided a brand new token for accessing the API.
+        v-text-field(
+          label="Token"
+          v-model="workspace.token"
+          readonly
+          :error-messages="workspace.errors.token"
+          :append-icon="showToken ? 'mdi-eye' : 'mdi-eye-off'"
+          :type="showToken ? 'text' : 'password'"
+          @click:append="showToken = !showToken"
+        )
+        v-btn(color="warning" @click="regenToken") Regenerate Token
+
+      v-alert.my-4(
         type="error"
         colored-border
         border="left"
@@ -40,6 +60,7 @@ export default {
   data() {
     return {
       dialog: false,
+      showToken: false,
       workspace: {
         errors: []
       }
@@ -68,6 +89,11 @@ export default {
     destroy: function () {
       this.$store.dispatch('workspaces/destroy', { workspace_id: this.$route.params.workspace_id }).then(() => {
         this.$router.push('/')
+      })
+    },
+    regenToken: function () {
+      this.$store.dispatch('workspaces/token', { workspace_id: this.$route.params.workspace_id }).then(() => {
+        this.workspace = this.$store.state.workspaces.list[this.$route.params.workspace_id]
       })
     }
   }

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,11 +1,11 @@
 class Session < ApplicationRecord
   attr_accessor :login
 
-  before_validation :generate_session_token, on: :create
+  belongs_to :user, optional: true
 
-  belongs_to :user
+  belongs_to :workspace, optional: true
 
-  validates :session_token, presence: true, uniqueness: true
+  has_secure_token
 
   def self.authenticate(params)
     user = User.authenticate(params)
@@ -21,12 +21,6 @@ class Session < ApplicationRecord
   end
 
   private
-
-  def generate_session_token
-    begin
-      self.session_token = SecureRandom.hex
-    end while self.class.exists?(session_token: session_token)
-  end
 
   def jwt_data
     {

--- a/app/models/workspace.rb
+++ b/app/models/workspace.rb
@@ -3,6 +3,8 @@ class Workspace < ApplicationRecord
 
   resourcify
 
+  has_secure_token
+
   belongs_to :created_by, class_name: 'User', foreign_key: 'user_id'
 
   has_many :users, through: :roles, class_name: 'User', source: :users

--- a/app/models/workspace.rb
+++ b/app/models/workspace.rb
@@ -3,9 +3,9 @@ class Workspace < ApplicationRecord
 
   resourcify
 
-  has_secure_token
-
   belongs_to :created_by, class_name: 'User', foreign_key: 'user_id'
+
+  has_one :session, dependent: :destroy
 
   has_many :users, through: :roles, class_name: 'User', source: :users
 
@@ -13,10 +13,24 @@ class Workspace < ApplicationRecord
 
   has_many :templates, dependent: :destroy
 
+  before_validation :generate_session, on: :create
+
+  validates_presence_of :session
+
   validates_presence_of :title
 
   validates_presence_of :slug
   validates_uniqueness_of :slug, message: 'is already taken'
   validates_format_of :slug, with: /\A(?:[a-z0-9][._-]?)*[a-z0-9]\z/i, message: 'must only contain letters, numbers, dashes and underscores (e.g. my_slug-1)'
   validates_format_of :slug, without: /\A\d+\Z/, message: 'cannot contain only numbers'
+
+  def token
+    session.token
+  end
+
+  private
+
+  def generate_session
+    create_session
+  end
 end

--- a/app/models/workspace.rb
+++ b/app/models/workspace.rb
@@ -13,7 +13,7 @@ class Workspace < ApplicationRecord
 
   has_many :templates, dependent: :destroy
 
-  before_validation :generate_session, on: :create
+  before_validation :create_session, on: :create
 
   validates_presence_of :session
 
@@ -26,11 +26,5 @@ class Workspace < ApplicationRecord
 
   def token
     session.token
-  end
-
-  private
-
-  def generate_session
-    create_session
   end
 end

--- a/app/policies/admin/entity_policy.rb
+++ b/app/policies/admin/entity_policy.rb
@@ -1,4 +1,4 @@
-class Admin::EntityPolicy < ApplicationPolicy
+class Admin::EntityPolicy < AdminPolicy
   def index?
     true
   end

--- a/app/policies/admin/settings_policy.rb
+++ b/app/policies/admin/settings_policy.rb
@@ -1,4 +1,4 @@
-class Admin::SettingsPolicy < ApplicationPolicy
+class Admin::SettingsPolicy < AdminPolicy
   def permitted_attributes
     [:name]
   end

--- a/app/policies/admin/template_policy.rb
+++ b/app/policies/admin/template_policy.rb
@@ -1,4 +1,4 @@
-class Admin::TemplatePolicy < ApplicationPolicy
+class Admin::TemplatePolicy < AdminPolicy
   def permitted_attributes
     [
       :name,

--- a/app/policies/admin/user_policy.rb
+++ b/app/policies/admin/user_policy.rb
@@ -1,4 +1,4 @@
-class Admin::UserPolicy < ApplicationPolicy
+class Admin::UserPolicy < AdminPolicy
   class Scope < Scope
     def resolve
       scope.all

--- a/app/policies/admin/workspace_policy.rb
+++ b/app/policies/admin/workspace_policy.rb
@@ -1,4 +1,4 @@
-class Admin::WorkspacePolicy < ApplicationPolicy
+class Admin::WorkspacePolicy < AdminPolicy
   def permitted_attributes
     [:title, :slug]
   end

--- a/app/policies/admin/workspace_policy.rb
+++ b/app/policies/admin/workspace_policy.rb
@@ -11,6 +11,10 @@ class Admin::WorkspacePolicy < ApplicationPolicy
     user&.has_role?(:admin, record)
   end
 
+  def token?
+    user&.has_role?(:admin, record)
+  end
+
   def destroy?
     user&.has_role?(:admin, record)
   end

--- a/app/policies/admin_policy.rb
+++ b/app/policies/admin_policy.rb
@@ -1,0 +1,7 @@
+class AdminPolicy < ApplicationPolicy
+  # TODO: Admin permissions are slightly more complex.
+  #       Update this file with common permissions.
+  #       Consider use of super to extend permissions
+  #       or some alternative using Rolify role arrays
+  #       that would be less database-hungry.
+end

--- a/app/policies/api/entity_policy.rb
+++ b/app/policies/api/entity_policy.rb
@@ -1,18 +1,6 @@
-class Api::EntityPolicy < ApplicationPolicy
+class Api::EntityPolicy < ApiPolicy
   def show?
-    record.published?
-  end
-
-  def create?
-    false
-  end
-
-  def update?
-    false
-  end
-
-  def destroy?
-    false
+    super && record.published?
   end
 
   class Scope < Scope

--- a/app/policies/api/template_policy.rb
+++ b/app/policies/api/template_policy.rb
@@ -1,18 +1,6 @@
-class Api::TemplatePolicy < ApplicationPolicy
+class Api::TemplatePolicy < ApiPolicy
   def show?
-    record.publishable
-  end
-
-  def create?
-    false
-  end
-
-  def update?
-    false
-  end
-
-  def destroy?
-    false
+    super && record.publishable
   end
 
   class Scope < Scope

--- a/app/policies/api/workspace_policy.rb
+++ b/app/policies/api/workspace_policy.rb
@@ -1,18 +1,6 @@
-class Api::WorkspacePolicy < ApplicationPolicy
+class Api::WorkspacePolicy < ApiPolicy
   def show?
-    true # TODO: Add public boolean to workspaces
-  end
-
-  def create?
-    false
-  end
-
-  def update?
-    false
-  end
-
-  def destroy?
-    false
+    super # TODO: Add public boolean to workspaces
   end
 
   class Scope < Scope

--- a/app/policies/api_policy.rb
+++ b/app/policies/api_policy.rb
@@ -1,0 +1,28 @@
+class ApiPolicy < ApplicationPolicy
+  # The public API disallows all mutations. Only
+  # READ operations are currently allowed.
+  def index?
+    workspace
+  end
+
+  def show?
+    workspace
+  end
+
+  def create?
+    false
+  end
+
+  def update?
+    false
+  end
+
+  def destroy?
+    false
+  end
+
+  # Helper Methods
+  def workspace
+    session.workspace
+  end
+end

--- a/app/policies/authentication/session_policy.rb
+++ b/app/policies/authentication/session_policy.rb
@@ -1,23 +1,9 @@
-class Authentication::SessionPolicy < ApplicationPolicy
+class Authentication::SessionPolicy < AuthenticationPolicy
   def permitted_attributes
     [:login, :password]
   end
 
-  def show?
+  def update?
     user && user == record.user
-  end
-
-  def create?
-    !user
-  end
-
-  def destroy?
-    user && user == record.user
-  end
-
-  class Scope < Scope
-    def resolve
-      scope.all
-    end
   end
 end

--- a/app/policies/authentication/user_policy.rb
+++ b/app/policies/authentication/user_policy.rb
@@ -1,27 +1,9 @@
-class Authentication::UserPolicy < ApplicationPolicy
+class Authentication::UserPolicy < AuthenticationPolicy
   def permitted_attributes
     [:name, :email, :password]
   end
 
-  def show?
-    user && user == record
-  end
-
-  def create?
-    !user
-  end
-
   def update?
     user && user == record
-  end
-
-  def destroy?
-    user && user == record
-  end
-
-  class Scope < Scope
-    def resolve
-      scope.all
-    end
   end
 end

--- a/app/policies/authentication_policy.rb
+++ b/app/policies/authentication_policy.rb
@@ -1,0 +1,16 @@
+class AuthenticationPolicy < ApplicationPolicy
+  # Authentication concerns the User and their single instance.
+  # The rules that apply to update? will always apply to show?
+  # and destroy? too.
+  def show?
+    update?
+  end
+
+  def create?
+    !user
+  end
+
+  def destroy?
+    update?
+  end
+end

--- a/app/views/admin/workspaces/_workspace.json.jbuilder
+++ b/app/views/admin/workspaces/_workspace.json.jbuilder
@@ -1,5 +1,9 @@
 json.extract! workspace, :id, :user_id, :title, :slug, :created_at, :updated_at
 
+if current_user.has_role?(:admin, workspace)
+  json.extract! workspace, :token
+end
+
 json.templates do
   json.array! workspace.templates, partial: "admin/templates/template", as: :template
 end

--- a/app/views/admin/workspaces/_workspace.json.jbuilder
+++ b/app/views/admin/workspaces/_workspace.json.jbuilder
@@ -1,7 +1,7 @@
 json.extract! workspace, :id, :user_id, :title, :slug, :created_at, :updated_at
 
 if current_user.has_role?(:admin, workspace)
-  json.extract! workspace, :token
+  json.token workspace.token
 end
 
 json.templates do

--- a/app/views/authentication/sessions/_session.json.jbuilder
+++ b/app/views/authentication/sessions/_session.json.jbuilder
@@ -1,4 +1,4 @@
-json.extract! session, :id, :session_token, :created_at, :updated_at
+json.extract! session, :id, :created_at, :updated_at
 json.jwt session.jwt
 
 json.url session_url(session, format: :json)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,10 @@ Rails.application.routes.draw do
     end
     # /admin/workspaces/*.json
     resources :workspaces, constraints: { id: /(?:[a-z0-9][._-]?)*[a-z0-9]/i } do
+      member do
+        # /admin/workspaces/:workspace_id/token.json
+        patch :token
+      end
       # /admin/workspaces/:workspace_id/users/*.json
       resources :users
       # /admin/workspaces/:workspace_id/templates/*.json

--- a/db/migrate/20200415143407_add_token_to_workspaces.rb
+++ b/db/migrate/20200415143407_add_token_to_workspaces.rb
@@ -1,6 +1,0 @@
-class AddTokenToWorkspaces < ActiveRecord::Migration[6.0]
-  def change
-    add_column :workspaces, :token, :string
-    add_index :workspaces, :token, unique: true
-  end
-end

--- a/db/migrate/20200415143407_add_token_to_workspaces.rb
+++ b/db/migrate/20200415143407_add_token_to_workspaces.rb
@@ -1,0 +1,6 @@
+class AddTokenToWorkspaces < ActiveRecord::Migration[6.0]
+  def change
+    add_column :workspaces, :token, :string
+    add_index :workspaces, :token, unique: true
+  end
+end

--- a/db/migrate/20200415181143_remove_session_token_from_sessions.rb
+++ b/db/migrate/20200415181143_remove_session_token_from_sessions.rb
@@ -1,0 +1,5 @@
+class RemoveSessionTokenFromSessions < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :sessions, :session_token
+  end
+end

--- a/db/migrate/20200415181200_add_token_to_sessions.rb
+++ b/db/migrate/20200415181200_add_token_to_sessions.rb
@@ -1,0 +1,6 @@
+class AddTokenToSessions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :sessions, :token, :string
+    add_index :sessions, :token, unique: true
+  end
+end

--- a/db/migrate/20200415181514_add_workspace_to_sessions.rb
+++ b/db/migrate/20200415181514_add_workspace_to_sessions.rb
@@ -1,0 +1,5 @@
+class AddWorkspaceToSessions < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :sessions, :workspace, foreign_key: true
+  end
+end

--- a/db/migrate/20200415182201_remove_null_constraint_for_users_on_sessions.rb
+++ b/db/migrate/20200415182201_remove_null_constraint_for_users_on_sessions.rb
@@ -1,0 +1,5 @@
+class RemoveNullConstraintForUsersOnSessions < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :sessions, :user_id, true
+  end
+end

--- a/db/migrate/20200415182435_generate_missing_tokens_for_existing_workspaces.rb
+++ b/db/migrate/20200415182435_generate_missing_tokens_for_existing_workspaces.rb
@@ -1,0 +1,10 @@
+class GenerateMissingTokensForExistingWorkspaces < ActiveRecord::Migration[6.0]
+  def up
+    Workspace.find_each do |workspace|
+      workspace.create_session
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_14_195649) do
+ActiveRecord::Schema.define(version: 2020_04_15_143407) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -96,7 +96,9 @@ ActiveRecord::Schema.define(version: 2020_04_14_195649) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "slug"
+    t.string "token"
     t.index ["slug"], name: "index_workspaces_on_slug", unique: true
+    t.index ["token"], name: "index_workspaces_on_token", unique: true
     t.index ["user_id"], name: "index_workspaces_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_15_143407) do
+ActiveRecord::Schema.define(version: 2020_04_15_182435) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,12 +38,14 @@ ActiveRecord::Schema.define(version: 2020_04_15_143407) do
   end
 
   create_table "sessions", force: :cascade do |t|
-    t.bigint "user_id", null: false
+    t.bigint "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "session_token"
-    t.index ["session_token"], name: "index_sessions_on_session_token", unique: true
+    t.string "token"
+    t.bigint "workspace_id"
+    t.index ["token"], name: "index_sessions_on_token", unique: true
     t.index ["user_id"], name: "index_sessions_on_user_id"
+    t.index ["workspace_id"], name: "index_sessions_on_workspace_id"
   end
 
   create_table "settings", force: :cascade do |t|
@@ -96,14 +98,13 @@ ActiveRecord::Schema.define(version: 2020_04_15_143407) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "slug"
-    t.string "token"
     t.index ["slug"], name: "index_workspaces_on_slug", unique: true
-    t.index ["token"], name: "index_workspaces_on_token", unique: true
     t.index ["user_id"], name: "index_workspaces_on_user_id"
   end
 
   add_foreign_key "entities", "templates"
   add_foreign_key "sessions", "users"
+  add_foreign_key "sessions", "workspaces"
   add_foreign_key "templates", "workspaces"
   add_foreign_key "workspaces", "users"
 end


### PR DESCRIPTION
## Linked Issue(s)

- closes #8 

## Description

- [x] Feature

Adds an API token to workspaces for accessing the public API. Also adds a regeneration button to the admin interface.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/thombruce/helvellyn/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/thombruce/helvellyn/blob/master/CODE_OF_CONDUCT.md)
