### PR TITLE
watch route for changes and reset currentWorkspace

### DIFF
--- a/app/javascript/src/mixins/workspaces.js
+++ b/app/javascript/src/mixins/workspaces.js
@@ -8,12 +8,22 @@ const workspaces = {
   created () {
     this.fetchWorkspaces()
   },
+  watch: {
+    '$route': 'setCurrentWorkspace'
+  },
   methods: {
     fetchWorkspaces () {
       this.$store.dispatch('workspaces/index').then(() => {
         this.workspaces = this.$store.state.workspaces.list
-        this.currentWorkspace = this.workspaces[this.$route.params.workspace_id]
+        this.setCurrentWorkspace()
       })
+    },
+    setCurrentWorkspace () {
+      if (this.$route.params.workspace_id) {
+        this.currentWorkspace = this.workspaces[this.$route.params.workspace_id]
+      } else {
+        this.currentWorkspace = null
+      }
     }
   }
 }


### PR DESCRIPTION
## Linked Issue(s)

- closes #41 

## Description

- [x] Bugfix

Watches the route for changes in Workspaces mixin, and resets currentWorkspace when changes occur.

Before the bug was introduced, I believe we were watching the route and pulling the data with every single change. Hence the decision to remove that logic.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/thombruce/helvellyn/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/thombruce/helvellyn/blob/master/CODE_OF_CONDUCT.md)
