### PR TITLE
add a basic mailer and deliver on signup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,12 +58,13 @@ end
 
 group :development do
   gem "brakeman", "~> 4.7"
-  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
+  gem 'letter_opener'
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem "rubocop", "~> 0.77.0"
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,10 @@ GEM
       activerecord
       kaminari-core (= 1.2.0)
     kaminari-core (1.2.0)
+    launchy (2.5.0)
+      addressable (~> 2.7)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -305,6 +309,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   jwt
   kaminari
+  letter_opener
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)

--- a/app.json
+++ b/app.json
@@ -2,10 +2,5 @@
   "name": "Helvellyn",
   "description": "A CMS with a customisable JSON API",
   "repository": "https://github.com/thombruce/helvellyn",
-  "keywords": ["rails", "vue", "cms", "json"],
-  "addons": [
-    {
-      "plan": "sendgrid:starter"
-    }
-  ]
+  "keywords": ["rails", "vue", "cms", "json"]
 }

--- a/app.json
+++ b/app.json
@@ -2,5 +2,10 @@
   "name": "Helvellyn",
   "description": "A CMS with a customisable JSON API",
   "repository": "https://github.com/thombruce/helvellyn",
-  "keywords": ["rails", "vue", "cms", "json"]
+  "keywords": ["rails", "vue", "cms", "json"],
+  "addons": [
+    {
+      "plan": "sendgrid:starter"
+    }
+  ]
 }

--- a/app/controllers/authentication/users_controller.rb
+++ b/app/controllers/authentication/users_controller.rb
@@ -21,6 +21,7 @@ class Authentication::UsersController < AuthenticationController
     authorize @user
 
     if @user.save
+      ConfirmationMailer.with(user: @user).confirmation_email.deliver_later
       @session = Session.create(user: @user)
       render :show, status: :created, location: @user
     else

--- a/app/javascript/src/views/admin/index.vue
+++ b/app/javascript/src/views/admin/index.vue
@@ -17,6 +17,22 @@ div
 
     v-text-field(label="Email" v-model="settings.email" :error-messages="settings.errors.email" hint="This is the email address that users will receive their welcome email from")
 
+    v-alert(
+      v-if="!settings.mailer_configured" 
+      type="warning"
+      colored-border
+      border="left"
+      elevation="2"
+    )
+      h4.title Oops!
+      p.body-1 You don't appear to have a mailer configured.
+      p.body-2
+        | You'll need to add the necessary variables to your app environment to send mail. For information on how to do this, see:
+        |
+        a(href="https://github.com/thombruce/helvellyn/wiki/Configure-Emails" target="_blank") Configure Emails
+        | .
+
+
     v-btn(color="primary" type="submit") Save
 </template>
 

--- a/app/javascript/src/views/admin/index.vue
+++ b/app/javascript/src/views/admin/index.vue
@@ -13,6 +13,8 @@ div
   v-form(v-if="settings" ref="form" :model="settings" @submit.prevent="update")
     v-text-field(label="Name" v-model="settings.name" :error-messages="settings.errors.name" hint="The name of your installation that will appear in the top left of every page")
 
+    v-text-field(label="Hostname" v-model="settings.hostname" :error-messages="settings.errors.hostname" hint="E.g. example.com")
+
     v-btn(color="primary" type="submit") Save
 </template>
 

--- a/app/javascript/src/views/admin/index.vue
+++ b/app/javascript/src/views/admin/index.vue
@@ -15,6 +15,8 @@ div
 
     v-text-field(label="Hostname" v-model="settings.hostname" :error-messages="settings.errors.hostname" hint="E.g. example.com")
 
+    v-text-field(label="Email" v-model="settings.email" :error-messages="settings.errors.email" hint="This is the email address that users will receive their welcome email from")
+
     v-btn(color="primary" type="submit") Save
 </template>
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'thom@thombruce.com'
+  default from: Settings.instance.email
   layout 'mailer'
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'thom@thombruce.com'
   layout 'mailer'
 end

--- a/app/mailers/confirmation_mailer.rb
+++ b/app/mailers/confirmation_mailer.rb
@@ -1,7 +1,8 @@
 class ConfirmationMailer < ApplicationMailer
   def confirmation_email
+    @settings = Settings.instance
     @user = params[:user]
-    @url  = root_url
-    mail(to: @user.email, subject: 'Welcome to Helvellyn') # TODO: This should reflect the app name
+    @url  = root_url(host: @settings.hostname)
+    mail(to: @user.email, subject: "Welcome to #{@settings.name}")
   end
 end

--- a/app/mailers/confirmation_mailer.rb
+++ b/app/mailers/confirmation_mailer.rb
@@ -1,0 +1,9 @@
+class ConfirmationMailer < ApplicationMailer
+  default from: 'notifications@example.com'
+ 
+  def confirmation_email
+    @user = params[:user]
+    @url  = root_url
+    mail(to: @user.email, subject: 'Welcome to Helvellyn') # TODO: This should reflect the app name
+  end
+end

--- a/app/mailers/confirmation_mailer.rb
+++ b/app/mailers/confirmation_mailer.rb
@@ -1,6 +1,4 @@
 class ConfirmationMailer < ApplicationMailer
-  default from: 'notifications@example.com'
- 
   def confirmation_email
     @user = params[:user]
     @url  = root_url

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -4,4 +4,8 @@ class Settings < ApplicationRecord
   def self.instance(*args)
     first_or_create!(args)
   end
+
+  def mailer_configured
+    !Rails.env.production? || Rails.application.config.action_mailer.smtp_settings[:user_name].present?
+  end
 end

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -1,7 +1,7 @@
 class Settings < ApplicationRecord
   validates :name, presence: true
 
-  def self.instance
-    first_or_create!
+  def self.instance(*args)
+    first_or_create!(args)
   end
 end

--- a/app/policies/admin/settings_policy.rb
+++ b/app/policies/admin/settings_policy.rb
@@ -1,6 +1,6 @@
 class Admin::SettingsPolicy < AdminPolicy
   def permitted_attributes
-    [:name]
+    [:name, :hostname]
   end
 
   def show?

--- a/app/policies/admin/settings_policy.rb
+++ b/app/policies/admin/settings_policy.rb
@@ -1,6 +1,6 @@
 class Admin::SettingsPolicy < AdminPolicy
   def permitted_attributes
-    [:name, :hostname]
+    [:name, :hostname, :email]
   end
 
   def show?

--- a/app/views/admin/settings/_settings.json.jbuilder
+++ b/app/views/admin/settings/_settings.json.jbuilder
@@ -1,3 +1,3 @@
-json.extract! settings, :name, :created_at, :updated_at
+json.extract! settings, :name, :hostname, :created_at, :updated_at
 
 json.url settings_url(format: :json)

--- a/app/views/admin/settings/_settings.json.jbuilder
+++ b/app/views/admin/settings/_settings.json.jbuilder
@@ -1,3 +1,3 @@
-json.extract! settings, :name, :hostname, :created_at, :updated_at
+json.extract! settings, :name, :hostname, :email, :created_at, :updated_at
 
 json.url settings_url(format: :json)

--- a/app/views/admin/settings/_settings.json.jbuilder
+++ b/app/views/admin/settings/_settings.json.jbuilder
@@ -1,3 +1,5 @@
 json.extract! settings, :name, :hostname, :email, :created_at, :updated_at
 
+json.mailer_configured settings.mailer_configured
+
 json.url settings_url(format: :json)

--- a/app/views/confirmation_mailer/confirmation_email.html.haml
+++ b/app/views/confirmation_mailer/confirmation_email.html.haml
@@ -1,0 +1,6 @@
+%h1= "Welcome to #{root_url}, #{@user.name}"
+%p
+  = "You have successfully signed up to #{root_url}, your username is: #{@user.login}."
+  %br/
+%p= "To login to the site, just follow this link: #{@url}."
+%p Thanks for joining and have a great day!

--- a/app/views/confirmation_mailer/confirmation_email.html.haml
+++ b/app/views/confirmation_mailer/confirmation_email.html.haml
@@ -1,6 +1,6 @@
-%h1= "Welcome to #{@url}, #{@user.name}"
+%h1= "Welcome to #{@settings.name}, #{@user.name}"
 %p
-  = "You have successfully signed up to #{@url}, your username is: #{@user.email}."
+  = "You have successfully signed up to #{@settings.name}, your username is: #{@user.email}."
   %br/
 %p= "To login to the site, just follow this link: #{@url}."
 %p Thanks for joining and have a great day!

--- a/app/views/confirmation_mailer/confirmation_email.html.haml
+++ b/app/views/confirmation_mailer/confirmation_email.html.haml
@@ -1,6 +1,6 @@
-%h1= "Welcome to #{root_url}, #{@user.name}"
+%h1= "Welcome to #{@url}, #{@user.name}"
 %p
-  = "You have successfully signed up to #{root_url}, your username is: #{@user.login}."
+  = "You have successfully signed up to #{@url}, your username is: #{@user.login}."
   %br/
 %p= "To login to the site, just follow this link: #{@url}."
 %p Thanks for joining and have a great day!

--- a/app/views/confirmation_mailer/confirmation_email.html.haml
+++ b/app/views/confirmation_mailer/confirmation_email.html.haml
@@ -1,6 +1,6 @@
 %h1= "Welcome to #{@url}, #{@user.name}"
 %p
-  = "You have successfully signed up to #{@url}, your username is: #{@user.login}."
+  = "You have successfully signed up to #{@url}, your username is: #{@user.email}."
   %br/
 %p= "To login to the site, just follow this link: #{@url}."
 %p Thanks for joining and have a great day!

--- a/app/views/confirmation_mailer/confirmation_email.text.haml
+++ b/app/views/confirmation_mailer/confirmation_email.text.haml
@@ -1,7 +1,7 @@
 = "Welcome to example.com, #{@user.name}"
-| ===============================================
+\===============================================
  
-= "You have successfully signed up to example.com, your username is: #{@user.login}."
+= "You have successfully signed up to example.com, your username is: #{@user.email}."
  
 = "To login to the site, just follow this link: #{@url}."
  

--- a/app/views/confirmation_mailer/confirmation_email.text.haml
+++ b/app/views/confirmation_mailer/confirmation_email.text.haml
@@ -1,0 +1,8 @@
+= "Welcome to example.com, #{@user.name}"
+| ===============================================
+ 
+= "You have successfully signed up to example.com, your username is: #{@user.login}."
+ 
+= "To login to the site, just follow this link: #{@url}."
+ 
+Thanks for joining and have a great day!

--- a/app/views/confirmation_mailer/confirmation_email.text.haml
+++ b/app/views/confirmation_mailer/confirmation_email.text.haml
@@ -1,7 +1,7 @@
-= "Welcome to example.com, #{@user.name}"
+= "Welcome to #{@settings.name}, #{@user.name}"
 \===============================================
  
-= "You have successfully signed up to example.com, your username is: #{@user.email}."
+= "You have successfully signed up to #{@settings.name}, your username is: #{@user.email}."
  
 = "To login to the site, just follow this link: #{@url}."
  

--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -1,0 +1,8 @@
+!!!
+%html
+  %head
+    %meta{:content => "text/html; charset=utf-8", "http-equiv" => "Content-Type"}/
+    :css
+      /* Email styles need to be inline */
+  %body
+    = yield

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,6 +36,10 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # Use Letter Opener gem to test mail sending in development
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,10 +68,10 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    :address              => (ENV['SENDGRID_USERNAME'] ? 'smtp.sendgrid.net' : nil) || ENV['MAILGUN_SMTP_SERVER'],
-    :port                 => ENV['MAILGUN_SMTP_PORT'] || 587,
-    :user_name            => ENV['SENDGRID_USERNAME'] || ENV['MAILGUN_SMTP_LOGIN'],
-    :password             => ENV['SENDGRID_PASSWORD'] || ENV['MAILGUN_SMTP_PASSWORD'],
+    :address              => (ENV['SENDGRID_USERNAME'] ? 'smtp.sendgrid.net' : nil) || ENV['MAILGUN_SMTP_SERVER'] || ENV['SMTP_SERVER'],
+    :port                 => ENV['MAILGUN_SMTP_PORT'] || ENV['SMTP_PORT'] || 587,
+    :user_name            => ENV['SENDGRID_USERNAME'] || ENV['MAILGUN_SMTP_LOGIN'] || ENV['SMTP_USERNAME'],
+    :password             => ENV['SENDGRID_PASSWORD'] || ENV['MAILGUN_SMTP_PASSWORD'] || ENV['SMTP_PASSWORD'],
     :authentication       => :plain,
     :enable_starttls_auto => true
   }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,6 +66,16 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    :address              => (ENV['SENDGRID_USERNAME'] ? 'smtp.sendgrid.net' : nil) || ENV['MAILGUN_SMTP_SERVER'],
+    :port                 => ENV['MAILGUN_SMTP_PORT'] || 587,
+    :user_name            => ENV['SENDGRID_USERNAME'] || ENV['MAILGUN_SMTP_LOGIN'],
+    :password             => ENV['SENDGRID_PASSWORD'] || ENV['MAILGUN_SMTP_PASSWORD'],
+    :authentication       => :plain,
+    :enable_starttls_auto => true
+  }
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/db/migrate/20200416010258_add_hostname_to_settings.rb
+++ b/db/migrate/20200416010258_add_hostname_to_settings.rb
@@ -1,0 +1,5 @@
+class AddHostnameToSettings < ActiveRecord::Migration[6.0]
+  def change
+    add_column :settings, :hostname, :string
+  end
+end

--- a/db/migrate/20200416153113_add_email_to_settings.rb
+++ b/db/migrate/20200416153113_add_email_to_settings.rb
@@ -1,0 +1,5 @@
+class AddEmailToSettings < ActiveRecord::Migration[6.0]
+  def change
+    add_column :settings, :email, :string, default: 'from@example.com'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_16_010258) do
+ActiveRecord::Schema.define(version: 2020_04_16_153113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 2020_04_16_010258) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "hostname"
+    t.string "email", default: "from@example.com"
     t.index ["singleton_guard"], name: "index_settings_on_singleton_guard", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_15_182435) do
+ActiveRecord::Schema.define(version: 2020_04_16_010258) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,6 +53,7 @@ ActiveRecord::Schema.define(version: 2020_04_15_182435) do
     t.string "name", default: "Helvellyn"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "hostname"
     t.index ["singleton_guard"], name: "index_settings_on_singleton_guard", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,4 +6,8 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-Settings.instance
+if app_name = ENV['HEROKU_APP_NAME']
+  Settings.instance(hostname: app_name + '.herokuapp.com')
+else
+  Settings.instance(hostname: 'example.com')
+end

--- a/spec/mailers/confirmation_mailer_spec.rb
+++ b/spec/mailers/confirmation_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe ConfirmationMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/confirmation_mailer_preview.rb
+++ b/spec/mailers/previews/confirmation_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/confirmation_mailer
+class ConfirmationMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
## Linked Issue(s)

- closes #7 

## Description

- [x] Feature

Adds a transactional mailer for user ~~confirmation~~ welcome emails. (Edit: We'll leave it as a welcome email for now, and separate out the confirmable user work for a later job, maybe #24 which might require invitation emails anyway)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/thombruce/helvellyn/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/thombruce/helvellyn/blob/master/CODE_OF_CONDUCT.md)
