### PR TITLE
enable email invites where mailer configured

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,8 @@ class User < ApplicationRecord
 
   has_many :entities, class_name: 'Entity', inverse_of: :created_by
 
-  validates :name, presence: true, on: :update # on: :update allows us to invite users by email without having to set their name
+  # validates :name, presence: true, on: :update # on: :update allows us to invite users by email without having to set their name
+  # TODO: No, it doesn't. Add a conditional to this validation based on confirmation.
 
   validates :email, presence: true
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }


### PR DESCRIPTION
## Linked Issue(s)

- closes #54 

## Description

- [x] Feature

Adds inviting by email if Settings.mailer_configured? and user does not previously exist in database.

## TODO

Will probably open additional issues, but:

- All mailing tasks currently use the same mailer: confirmation_mailer. Setup additional
- Fix validations / tidy up user model

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/thombruce/helvellyn/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/thombruce/helvellyn/blob/master/CODE_OF_CONDUCT.md)
