### PR TITLE
overwrite default mailer settings in ApplicationMailer

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,10 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'helvellyn@thombruce.com'
+  default from: Settings.instance.email || 'helvellyn@thombruce.com'
   layout 'mailer'
+
+  private
+
+  def default_url_options
+    { host: Settings.instance.hostname }
+  end
 end


### PR DESCRIPTION
## Linked Issue(s)

- closes #65 

## Description

### Feature

Allow setting of URL and email on mailers.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/thombruce/helvellyn/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/thombruce/helvellyn/blob/master/CODE_OF_CONDUCT.md)
